### PR TITLE
Use django.apps.apps.get_model for Django 1.9 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IntelliJ
+*.iml

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project was heavily influence by [django-rest-hooks](https://github.com/zap
 
 ## Install
 
-    pip install django_objects_hooks
+    pip install django-objects-hooks
 
 ## Basic usage
 

--- a/src/doh/deliverers/base.py
+++ b/src/doh/deliverers/base.py
@@ -1,5 +1,4 @@
 from django.db.models import Q
-from django.db.models.loading import get_model
 from django.conf import settings
 from requests.exceptions import MissingSchema
 from requests.exceptions import InvalidSchema
@@ -11,6 +10,11 @@ import datetime
 import ujson
 import requests
 import celery
+try:
+    from django.apps import apps
+    get_model = apps.get_model
+except ImportError:
+    from django.db.models.loading import get_model
 
 
 class HooksDeliverer(celery.task.Task, DelivererMixin):


### PR DESCRIPTION
`django.db.models.loading.get_model` has been removed in Django 1.9. This small change should allow it to work in older and current Django versions.
Also fixed a little typo in Readme for the pip install package name.
