### PR TITLE
Use timedelta for expiration date calculation

### DIFF
--- a/src/doh/models.py
+++ b/src/doh/models.py
@@ -7,14 +7,14 @@ except ImportError:
 from django.contrib.contenttypes.models import ContentType
 from django.core.validators import URLValidator
 from django.utils import timezone
+from datetime import timedelta
 from .managers import HookQuerySet
 
 
 def get_expiration_date():
     now = timezone.now()
-    return now.replace(
-        year=now.year +getattr(settings, "HOOK_EXPIRATION_DATE_DELTA", 10)
-    )
+    return now + timedelta(
+        days=365 * getattr(settings, "HOOK_EXPIRATION_DATE_DELTA", 10))
 
 
 class Hook(models.Model):


### PR DESCRIPTION
Got hit by this today. get_expiration_date was failing today due to it being a leap day. Replacing the datetime, results in it trying to set the date to 29th February 10 years in the future resulting in a `ValueError: day is out of range for month`. Fixed to use a timedelta with years estimate in days.
